### PR TITLE
Add RipSound Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ unknown_pictures
 
 # No more mac nonsense
 .DS_Store
+
+sound_clips

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get install -y --fix-missing \
     libgraphicsmagick1-dev \
     libatlas-dev \
     libavcodec-dev \
+    libavcodec-extra-56 \ 
     libavformat-dev \
     libav-tools \
     libffi-dev \

--- a/mega-mod-bot/commands/ripsound.py
+++ b/mega-mod-bot/commands/ripsound.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""
+This module is responsible for the ripsound command.
+
+The main functionality of this module will involve fetching youtube videos,
+ripping the sound from the videos, isolating a specific part of the audio
+and save it for playback in the future.
+
+Command Format:
+$ripsound <clip_name> <youtube_URL> <start_time_seconds> <end_time_seconds>
+
+Sample Ripsound command:
+`$ripsound perfect_line https://www.youtube.com/watch?v=oYmqJl4MoNI 84 89`
+
+TODO:
+    1) Add overwrite protection.
+    2) Persist file names once we use some persistent storage.
+"""
+
+import youtube_dl
+import os
+
+from pydub import AudioSegment
+
+
+DOWNLOAD_LOCATION = 'sound_clips/'
+
+
+def execute_ripsound(tokens):
+    """Interface for the ripsound module."""
+    # TODO: Put in validation of the tokens.
+    clip_name = tokens[1]
+    video_url = tokens[2]
+    start_time_ms = int(tokens[3]) * 1000
+    end_time_ms = int(tokens[4]) * 1000
+    save_location = DOWNLOAD_LOCATION + clip_name
+
+    # Need to use %(ext) otherwise ffmpeg bugs out. This uglies things a bit.
+    options = {
+        'format': 'bestaudio/best',
+        'postprocessors': [{
+            'key': 'FFmpegExtractAudio',
+            'preferredcodec': 'mp3',
+            'preferredquality': '192',
+        }],
+        'outtmpl': save_location + '.%(ext)s',
+    }
+    with youtube_dl.YoutubeDL(options) as downloader:
+        downloader.download([video_url])
+
+    audio_location = save_location + '.mp3'
+    trim_and_export_audio(audio_location, clip_name, start_time_ms,
+                          end_time_ms)
+    os.remove(audio_location)
+
+
+def trim_and_export_audio(save_location, clip_name, start_ms, end_ms):
+    """Trim and export audio clip."""
+    temp_sound_file = AudioSegment.from_file(save_location, format='mp3')
+    file_location = DOWNLOAD_LOCATION + clip_name + '.wav'
+    return temp_sound_file[start_ms:end_ms].export(file_location, format='wav')

--- a/mega-mod-bot/mega-mod-bot.py
+++ b/mega-mod-bot/mega-mod-bot.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-This is the primary module for mega-mob-bot.
+This is the primary module for mega-mod-bot.
 
 It's primary function is to parse all messages, identify ones that are relevant
 to mega-mod-bot and dispatch them accordingly. It handles all text and voice
@@ -11,6 +11,7 @@ import discord
 import logging
 import os
 from censor import contains_banned_content
+from commands.ripsound import execute_ripsound
 
 
 logging.basicConfig(level=logging.INFO)
@@ -40,7 +41,7 @@ async def on_message(message):
         return None
 
     if message.content.startswith(COMMAND_SYMBOL):
-        resolve_command(message)
+        execute_command(message)
     else:
         await remove_banned_content(message)
 
@@ -52,11 +53,13 @@ async def remove_banned_content(message):
         await remove_message(message)
 
 
-def resolve_command(message):
-    """Tokenize and resolve command string."""
+def execute_command(message):
+    """Tokenize and execute command string."""
     tokens = message.content[1:].split(' ')
+    # TODO: Automatically do this by pulling command names from the command dir
+    # TODO: Add error handling on invalid command
     if (tokens[0] == 'ripsound'):
-        pass
+        execute_ripsound(tokens)
 
 
 async def send_message(channel, message_string):

--- a/mega-mod-bot/mega-mod-bot.py
+++ b/mega-mod-bot/mega-mod-bot.py
@@ -58,6 +58,9 @@ def execute_command(message):
     tokens = message.content[1:].split(' ')
     # TODO: Automatically do this by pulling command names from the command dir
     # TODO: Add error handling on invalid command
+    # TODO: Returning a tuple can help us figure out if we need to send a text
+    #       or voice message while keeping this module as the main text/voice
+    #       bus.
     if (tokens[0] == 'ripsound'):
         execute_ripsound(tokens)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ face_recognition>=1.0.0
 asyncio>=3.4.3
 requests>=2.18.4
 python-dotenv>=0.7.1
+pydub>=0.21.0
+youtube_dl>=2018.3.3


### PR DESCRIPTION
This PR adds the `ripsound` command which is capable of downloading a youtube video, extracting the audio, slicing the audio into the portion we want, then exporting the soundclip for future use.

Kind of rudimentary at this moment, lacking any validation and overwrite protection. Since we will be having multiple commands around this youtube audio clip functionality (ripping, playing, and listing) it'll probably make sense to pull all of that into a single module that handles the entire functionality. It definitely feels like the case where one "thing" should handle all three of the pieces as opposed to scattered related functionality in multiple commands.